### PR TITLE
Switched version number to date

### DIFF
--- a/buildSrc/src/main/groovy/wtmp.versioning-conventions.gradle
+++ b/buildSrc/src/main/groovy/wtmp.versioning-conventions.gradle
@@ -1,7 +1,18 @@
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
 plugins {
     id "com.palantir.git-version"
     id "org.ajoberstar.grgit"
 }
+
+def dateVersion() {
+    def fmt = DateTimeFormatter.ofPattern("yyyy.MM.dd") // format: YYYY.MM.DD
+    return LocalDate.now().format(fmt)
+}
+
+version = dateVersion()
 
 tasks.register("showGit") {
     doFirst {
@@ -14,49 +25,12 @@ tasks.register("showGit") {
     }
 }
 
-def versionLabel(gitInfo) {
-    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
-    if (branch == null && !"$System.env.CI_COMMIT_BRANCH".isEmpty()) {
-        branch = "$System.env.CI_COMMIT_BRANCH" // Gitlab CI checks out a commit, not a branch. Grab the branch name from the env vars it sets
-    }
-    def tag = gitInfo.lastTag
-    // tag is returned as is. Branch may need cleanup
-    return (branch == null || branch == "null" || branch.isEmpty()) ? tag : branch.replace("/","-") + "-SNAPSHOT"
-}
-
-/**
- * When running on the Build System (eg TeamCity) will get BUILD_NUMBER
- * Otherwise, gets the current commit (and status)
- */
-String getBuildID() {
-    if(project.version.contains("-SNAPSHOT")) {
-        def buildNum = System.env.BUILD_NUMBER
-        if (!buildNum?.trim()) {
-            buildNum = "-${grgit.head().abbreviatedId}"
-            def clean = grgit.status().isClean()
-            if (!clean) {
-                buildNum += "+"
-            }
-        } else {
-            buildNum = "." + buildNum
-        }
-        return buildNum
-    } else {
-        // If dirty, return "+"
-        return grgit.status().isClean() ? "" : "+"
-    }
-}
-
 String getShortVersionName() {
-    String shortVersion = project.version
-    if(shortVersion.contains("-SNAPSHOT")) {
-        shortVersion = shortVersion.substring(0, shortVersion.indexOf("-SNAPSHOT"))
-    }
-    return shortVersion
+    return project.version.toString()
 }
 
 String getConventionVersion() {
-    return versionLabel(versionDetails())
+    return project.version.toString()
 }
 
 project.getExtensions().add("versionConventions", this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-usbr-git-library = "main-SNAPSHOT"
+usbr-git-library = "2026.03.25"
 
 hec-wat = "1.1.0.15-beta"
 wat-cequalw2 = "v1.1-2.0.0.1149-20210903.004433-1"
-merlin-data-exchange = "main-SNAPSHOT"
+merlin-data-exchange = "2026.03.25"
 
 jasper-version = "6.17.0"
 poi = "3.8"


### PR DESCRIPTION
The version number is now always the date (yyyy.mm.dd). Updated version number for other repos. Previously was based on branch/tags.