### PR TITLE
Updated WAT version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 usbr-git-library = "2026.03.25"
 
-hec-wat = "1.1.0.15-beta"
+hec-wat = "1.1.0.0"
 wat-cequalw2 = "v1.1-2.0.0.1149-20210903.004433-1"
 merlin-data-exchange = "2026.03.25"
 


### PR DESCRIPTION
Updated WAT version to the non-beta 1.1.0.0 version. Previously we were using a beta version.

This built successfully on my fork.